### PR TITLE
Add kalikiana.gitlab.io to the planet

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -1371,6 +1371,13 @@ title = Planet openSUSE
   location = en
   author   = irc:tux_
 
+[kalikiana]
+  title    = Cris' blog
+  feed     = https://kalikiana.gitlab.io/index.xml
+  link     = https://kalikiana.gitlab.io
+  location = en
+  author   = connect:cdywan irc:kalikiana member
+
 [timojyrinki]
   title    = Timo's openSUSE Posts
   feed     = https://timojyrinki.gitlab.io/hugo/index.xml


### PR DESCRIPTION
My new blog is up on [kalikiana.gitlab.io](https://kalikiana.gitlab.io/)